### PR TITLE
Rewrite typing tactic to be more precise using a recursive approach

### DIFF
--- a/BoogieLang/HelperML.thy
+++ b/BoogieLang/HelperML.thy
@@ -13,6 +13,19 @@ fun assm_full_simp_solved_tac ctxt = (asm_full_simp_tac ctxt |> SOLVED')
 fun assm_full_simp_solved_with_thms_tac thms ctxt = (asm_full_simp_tac (add_simps thms ctxt) |> SOLVED')
 
 fun fastforce_tac ctxt thms = Clasimp.fast_force_tac (add_simps thms ctxt)
+\<close>                                     
+
+ML 
+\<open>
+
+fun THEN_ELSE' cond_tac (then_tac, else_tac) i = 
+    (cond_tac i) THEN_ELSE (then_tac i, else_tac i)
+
+fun FIRST_AND_THEN' [] []  = K no_tac
+  | FIRST_AND_THEN' (_ :: _) [] = error "FIRST_AND_THEN' invoked with different argument lengths"
+  | FIRST_AND_THEN' [] (_ :: _) = error "FIRST_AND_THEN' invoked with different argument lengths"
+  | FIRST_AND_THEN' (cand_tac :: cs) (follow_tac :: fs) =
+      THEN_ELSE' cand_tac (follow_tac, FIRST_AND_THEN' cs fs)
 
 (* The following tactic runs the input tactic on an input theorem. If the tactic fails, then NONE
    is returned. If the tactic succeeds, then the first possible outcome is returned (wrapped by Some).*)   
@@ -20,10 +33,7 @@ fun simulate_determ_tac tac st =
   (case Seq.pull (tac st) of
             NONE => NONE
           | SOME (st', _) => SOME st')
-\<close>                                     
 
-ML 
-\<open>
 (* apply tactic that takes the number of goals as first input *)
 fun tactic_ngoals tac st =
   let 

--- a/BoogieLang/HelperML.thy
+++ b/BoogieLang/HelperML.thy
@@ -21,6 +21,9 @@ ML
 fun THEN_ELSE' cond_tac (then_tac, else_tac) i = 
     (cond_tac i) THEN_ELSE (then_tac i, else_tac i)
 
+
+(* FIRST_AND_THEN' cs fs applies the first tactic in cs that works and then applies the corresponding
+   tactic in fs at the same position. *)
 fun FIRST_AND_THEN' [] []  = K no_tac
   | FIRST_AND_THEN' (_ :: _) [] = error "FIRST_AND_THEN' invoked with different argument lengths"
   | FIRST_AND_THEN' [] (_ :: _) = error "FIRST_AND_THEN' invoked with different argument lengths"

--- a/BoogieLang/TypingHelper.thy
+++ b/BoogieLang/TypingHelper.thy
@@ -20,6 +20,16 @@ lemma typ_binop_poly_helper:
   using assms TypBinopPoly
   by blast
 
+lemma typ_binop_poly_helper_2:
+  assumes "binop_poly_type bop" and
+          "hint_ty_subst ty_inst" and
+          "F,\<Delta> \<turnstile> e1 : ty1" and
+          "F,\<Delta> \<turnstile> e2 : ty2" and          
+          "msubstT_opt ty_inst ty1 = msubstT_opt ty_inst ty2"
+  shows "F,\<Delta> \<turnstile> e1 \<guillemotleft>bop\<guillemotright> e2 : TPrim (TBool)"
+  using assms TypBinopPoly
+  by blast
+
 lemma typ_binop_poly_helper_empty:
   assumes "binop_poly_type bop" and
           "F,\<Delta> \<turnstile> e1 : ty1" and

--- a/BoogieLang/TypingML.thy
+++ b/BoogieLang/TypingML.thy
@@ -129,6 +129,8 @@ fun typing_tac ctxt hint_thm_tree lookup_assms func_assms =
           assm_full_simp_solved_tac ctxt
         )
      | _ => error("hints not in correct format for binop mono")
+
+fun typing_tac_no_hints ctxt lookup_assms func_assms = typing_tac ctxt NoPolyHint lookup_assms func_assms
 \<close>
 
 end

--- a/BoogieLang/TypingML.thy
+++ b/BoogieLang/TypingML.thy
@@ -9,12 +9,14 @@ To prove a typing relation in the presence of type variables, one needs to know 
 type variable substitution to use for equality and inequality.
 The tactic implemented here takes this information in the form of a tree (see typing_poly_hint) that
 reflects the structure of the expression to be typed. At each node of the tree, the hint is either
-NoPolyHint (in which case no hint is required for that entire subtree) or PolyyHintNode (in which
+NoPolyHint (in which case no hint is required for that entire subtree) or PolyHintNode (in which
 case there is a potential theorem indicating what needs to be applied at that point and a hint tree
 for each subnode). 
 For optimization reasons, we use trees that only reflect nodes that can branch (i.e., binary
-operations and function calls currently). For all other nodes no hint is required and since they
-only have one subnode one does not need to represent them using a separate node. 
+operations and function calls currently). For all other nodes (i.e., those with only one subnode)
+no hint is required and the hint tree should not represent them using a separate node. This means
+the hint tree reflects the structure of the expression where consecutive nodes with only single 
+subnodes are merged.
 *)
 
 datatype typing_poly_hint = NoPolyHint | PolyHintNode of (thm option * (typing_poly_hint list))

--- a/BoogieLang/TypingML.thy
+++ b/BoogieLang/TypingML.thy
@@ -1,85 +1,134 @@
-theory TypingML                                      
+theory TypingML        
   imports TypingHelper HelperML
 begin               
 
 ML \<open>
 
-fun binop_mono_tac ctxt lookup_assms func_assms =
-  FIRST' [  
-  resolve_tac ctxt [@{thm TypVar}] THEN' (assm_full_simp_solved_tac (ctxt addsimps lookup_assms)),
-  resolve_tac ctxt [@{thm TypBVar}] THEN' assm_full_simp_solved_tac ctxt,
-  resolve_tac ctxt [@{thm TypPrim}] THEN' assm_full_simp_solved_tac ctxt,
-  resolve_tac ctxt [@{thm TypUnOp}],
-  resolve_tac ctxt [@{thm TypBinOpMono}] THEN' assm_full_simp_solved_tac ctxt,
-  resolve_tac ctxt [@{thm typ_funexp_helper}] THEN' (assm_full_simp_solved_tac (ctxt addsimps func_assms)) THEN'
-    assm_full_simp_solved_tac ctxt THEN' assm_full_simp_solved_tac ctxt THEN' 
-    (* goal: \<tau> = (msubstT_opt ty_params ret_ty) *)
-    asm_full_simp_tac (ctxt addsimps [@{thm msubstT_opt_def}]) THEN'
-  (* before this final tactic the goal is of the form \<open>map (msubstT_opt ty_params) args_ty\<close>, which we want to simplify fully *)
-    asm_full_simp_tac (ctxt addsimps [@{thm msubstT_opt_def}]),
-  resolve_tac ctxt [@{thm TypOld}],
-  resolve_tac ctxt [@{thm TypForall}],
-  resolve_tac ctxt [@{thm TypExists}],
-  resolve_tac ctxt [@{thm TypForallT}],
-  resolve_tac ctxt [@{thm TypExistsT}],
-  resolve_tac ctxt [@{thm TypListNil}],
-  resolve_tac ctxt [@{thm TypListCons}]
-  ]
-
-fun binop_poly_tac ctxt hint_thm =  
-  resolve_tac ctxt ([@{thm typ_binop_poly_helper} OF [hint_thm]]) THEN'
-  assm_full_simp_solved_tac ctxt
-
-fun binop_poly_tac_no_hint ctxt =  
-  resolve_tac ctxt ([@{thm typ_binop_poly_helper_empty}]) THEN'
-  assm_full_simp_solved_tac ctxt
-
 (*
-hint_thms must provide the type substitutions as theorems (see TypingHelper.thy)
-for the equality operators, where the order is given from left to right.
-
-simulate_determ_tac is used to check whether a tactic succeeds (in which case typing_tac continues).
-Note that this tactic does not track how many subgoals were generated and still need to be solved from
-the initial subgoal. As a result, it is possible that the tactic solves a goal that was generated
-from the original subgoal. We might want to adjust that.
+To prove a typing relation in the presence of type variables, one needs to know what 
+type variable substitution to use for equality and inequality.
+The tactic implemented here takes this information in the form of a tree (see typing_poly_hint) that
+reflects the structure of the expression to be typed. At each node of the tree, the hint is either
+NoPolyHint (in which case no hint is required for that entire subtree) or PolyyHintNode (in which
+case there is a potential theorem indicating what needs to be applied at that point and a hint tree
+for each subnode). 
+For optimization reasons, we use trees that only reflect nodes that can branch (i.e., binary
+operations and function calls currently). For all other nodes no hint is required and since they
+only have one subnode one does not need to represent them using a separate node. 
 *)
-fun typing_tac ctxt hint_thms lookup_assms func_assms i st =  
-let val simp_solve_continue = 
-   (case simulate_determ_tac (assm_full_simp_solved_tac (ctxt addsimps [@{thm msubstT_opt_def}]) i) st of
-      NONE => Seq.single st
-    | SOME st' => typing_tac ctxt hint_thms lookup_assms func_assms i st'
-   )
-in
-  (case simulate_determ_tac (binop_mono_tac ctxt lookup_assms func_assms i) st of
-    NONE => 
-      (case hint_thms of
-         [] => simp_solve_continue
-       | (hint :: hint_rest) => 
-         (case simulate_determ_tac (binop_poly_tac ctxt hint i) st of
-            NONE => simp_solve_continue
-          | SOME st' => typing_tac ctxt hint_rest lookup_assms func_assms i st'))
-   | SOME st' => typing_tac ctxt hint_thms lookup_assms func_assms i st'
-  )
-end
 
-(* The following tactic is the same as typing_tac except where no hints are used for polymorphic 
-   binary operators (i.e., equality and inequality). This is useful in cases where the identity 
-   substitution is sufficient to type polymorphic binary operators. *)
-fun typing_tac_no_hints ctxt lookup_assms func_assms i st =  
-let val simp_solve_continue = 
-   (case simulate_determ_tac (assm_full_simp_solved_tac (ctxt addsimps [@{thm msubstT_opt_def}]) i) st of
-      NONE => Seq.single st
-    | SOME st' => typing_tac_no_hints ctxt lookup_assms func_assms i st'
-   )
-in
-  (case simulate_determ_tac (binop_mono_tac ctxt lookup_assms func_assms i) st of
-    NONE => 
-      (case simulate_determ_tac (binop_poly_tac_no_hint ctxt i) st of
-            NONE => simp_solve_continue
-          | SOME st' => typing_tac_no_hints ctxt  lookup_assms func_assms i st')
-   | SOME st' => typing_tac_no_hints ctxt lookup_assms func_assms i st'
-  )
-end
+datatype typing_poly_hint = NoPolyHint | PolyHintNode of (thm option * (typing_poly_hint list))
+
+fun has_poly_hint NoPolyHint = false
+ |  has_poly_hint (PolyHintNode (NONE, _ )) = false
+ |  has_poly_hint (PolyHintNode (SOME _, _ )) = true
+
+fun the_poly_hint NoPolyHint = error("invoked the_poly_hint on NoPolyHint")
+  | the_poly_hint (PolyHintNode (thm, hints)) = (thm, hints)
+
+fun typing_tac ctxt hint_thm_tree lookup_assms func_assms =  
+  FIRST_AND_THEN' 
+    [ resolve_tac ctxt [@{thm TypVar}],
+      resolve_tac ctxt [@{thm TypBVar}],
+      resolve_tac ctxt [@{thm TypPrim}],
+      resolve_tac ctxt [@{thm TypUnOp}],
+      resolve_tac ctxt [@{thm TypBinOpMono}] THEN' assm_full_simp_solved_tac ctxt,
+      if has_poly_hint hint_thm_tree then
+        resolve_tac ctxt [@{thm typ_binop_poly_helper_2}] THEN' assm_full_simp_solved_tac ctxt
+      else 
+        resolve_tac ctxt [@{thm typ_binop_poly_helper_empty}] THEN' assm_full_simp_solved_tac ctxt,
+      resolve_tac ctxt [@{thm typ_funexp_helper}],
+      resolve_tac ctxt [@{thm TypOld}],
+      resolve_tac ctxt [@{thm TypForall}],
+      resolve_tac ctxt [@{thm TypExists}],
+      resolve_tac ctxt [@{thm TypForallT}],
+      resolve_tac ctxt [@{thm TypExistsT}]
+    ]
+    [ (* Var *)
+      assm_full_simp_solved_tac (ctxt addsimps lookup_assms),
+      (* BVar *)
+      assm_full_simp_solved_tac ctxt,
+      (* Prim *)
+      assm_full_simp_solved_tac ctxt, 
+      (* Unop *)
+      fn i => fn st => (((typing_tac ctxt hint_thm_tree lookup_assms func_assms) |> SOLVED') THEN' 
+                      assm_full_simp_solved_tac ctxt) i st,
+      (* Binop Mono *)
+      fn i => fn st => (i,st) |-> (
+                        let val (hints1, hints2) = 
+                                case hint_thm_tree of
+                                  NoPolyHint => (NoPolyHint, NoPolyHint)
+                                | PolyHintNode (_, ([h1, h2])) => (h1, h2)
+                                | _ => error("hints not in correct format for binop mono")
+
+                                   in
+                        (typing_tac ctxt hints1 lookup_assms func_assms |> SOLVED') THEN'
+                        (typing_tac ctxt hints2 lookup_assms func_assms |> SOLVED') THEN' 
+                        assm_full_simp_solved_tac ctxt
+                        end
+                       ),
+
+      (* Binop Poly *)
+      binop_poly_tac ctxt hint_thm_tree lookup_assms func_assms,
+      (* FunExp *)
+      (assm_full_simp_solved_tac (ctxt addsimps func_assms)) THEN'
+      assm_full_simp_solved_tac ctxt THEN' assm_full_simp_solved_tac ctxt THEN' 
+        (* goal: \<tau> = (msubstT_opt ty_params ret_ty) *)
+      asm_full_simp_tac (ctxt addsimps [@{thm msubstT_opt_def}]) THEN'
+        (* before this final tactic the goal is of the form \<open>map (msubstT_opt ty_params) args_ty\<close>, which we want to simplify fully *)
+      asm_full_simp_tac (ctxt addsimps [@{thm msubstT_opt_def}]) THEN'
+      typing_list_tac ctxt hint_thm_tree lookup_assms func_assms,
+
+      (* Old *)
+      fn i => fn st  => ((typing_tac ctxt hint_thm_tree lookup_assms func_assms) |> SOLVED') i st,
+    
+      (* Forall *)
+      fn i => fn st => ((typing_tac ctxt hint_thm_tree lookup_assms func_assms) |> SOLVED') i st,
+
+      (* Exists *)
+      fn i => fn st => ((typing_tac ctxt hint_thm_tree lookup_assms func_assms) |> SOLVED') i st,
+
+      (* ForallT *)
+      fn i => fn st => ((typing_tac ctxt hint_thm_tree lookup_assms func_assms) |> SOLVED') i st,
+
+      (* ExistsT *)
+      fn i => fn st => ((typing_tac ctxt hint_thm_tree lookup_assms func_assms) |> SOLVED') i st
+    ]
+ and  
+   typing_list_tac ctxt hint_thm_tree lookup_assms func_assms = 
+      resolve_tac ctxt [@{thm TypListNil}] ORELSE'
+      (resolve_tac ctxt [@{thm TypListCons}] THEN' 
+       (fn i => fn st => (i, st) |-> 
+                          ( let val (hint1, hint_tail) = 
+                                  case hint_thm_tree of
+                                    NoPolyHint => (NoPolyHint, NoPolyHint)
+                                  | PolyHintNode (t, h1 :: htail) => (h1, PolyHintNode (t, htail))
+                                  | _ => error("hints not in correct format for binop mono")
+                            in
+                            (typing_tac ctxt hint1 lookup_assms func_assms |> SOLVED') THEN' 
+                            (typing_list_tac ctxt hint_tail lookup_assms func_assms)
+                            end
+                          )
+       )
+      )
+ and 
+   binop_poly_tac ctxt hint_thm_tree lookup_assms func_assms i st = 
+      case hint_thm_tree of
+       PolyHintNode (hint_thm_opt, [h1,h2]) => 
+        (i, st) |->
+        ( (if is_some hint_thm_opt then resolve_tac ctxt [the hint_thm_opt] else K all_tac) THEN'
+          ((typing_tac ctxt h1 lookup_assms func_assms) |> SOLVED') THEN'
+          ((typing_tac ctxt h2 lookup_assms func_assms) |> SOLVED') THEN' 
+          assm_full_simp_solved_tac (ctxt addsimps [@{thm msubstT_opt_def}])
+        )
+      | NoPolyHint => 
+        (i, st) |->
+        ( 
+          ((typing_tac ctxt NoPolyHint lookup_assms func_assms) |> SOLVED') THEN'
+          ((typing_tac ctxt NoPolyHint lookup_assms func_assms) |> SOLVED') THEN' 
+          assm_full_simp_solved_tac ctxt
+        )
+     | _ => error("hints not in correct format for binop mono")
 \<close>
 
 end


### PR DESCRIPTION
Previously, the typing tactic (i.e, the tactic used to prove that a Boogie expression is well-typed) repeatedly invoked typing rules and whenever a typing rule could not be applied because the invocation of a typing rule led to some other kind of subgoal, the tactic applied the simplifier with some extra definitions to solve those goals. The problem with this approach is that 1) the tactic is hard to understand, 2) the tactic is hard to extend if the simplifier is not sufficient to deal with all kinds of goals, 3) the tactic potentially solves too many goals (i.e., subgoals that already existed before the tactic was invoked) because the simplifier is often applied if the tactic cannot continue., 4) the tactic tries out many typing rules in cases where it is unnecessary.

To solve theses issues, this pull request rewrites the typing tactic. For example, if the binary operation typing rule applies, then the tactic directly invokes the typing tactic recursively twice (left and right operand) followed by invoking the simplifier once (final subgoal of tactic). The old hint approach for equality and inequality type variable substitutions does not work well with this approach and so, this PR also changes the hint approach slightly. Previously, the type variable substitutions were represented using a list of theorems (each theorem representing an equality or inequality, theorems earlier in the list referred to equalities appearing earlier when taking a depth-first order). Now, type variable substitutions are represented using a tree of theorems. Moreover, now also the hint representation is optimized in the case where no type variable substitutions are required (because there are no type variables involved).